### PR TITLE
Can tag users instead of giving codeforces handle for some commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The features of the bot are split into a number of cogs, each handling their own
 ## Installation
 Clone the repository
 ```bash
-git clone https://github.com/Groverkss/TLE
+git clone https://github.com/Vidit-Jain/TLE
 ```
 
 > :warning: **TLE requires Python 3.7 or later!**

--- a/run.sh
+++ b/run.sh
@@ -7,8 +7,8 @@ cd "$(dirname "$0")"
 
 while true; do
     git pull
-    pip3 install -r requirements.txt
-    FONTCONFIG_FILE=$PWD/extra/fonts.conf python3 __main__.py
+    python3.8 -m pip install -r requirements.txt
+    FONTCONFIG_FILE=$PWD/extra/fonts.conf python3.8 __main__.py
 
     (( $? != 42 )) && break
 

--- a/tle/cogs/codeforces.py
+++ b/tle/cogs/codeforces.py
@@ -24,6 +24,16 @@ _GITGUD_MAX_ABS_DELTA_VALUE = 300
 class CodeforcesCogError(commands.CommandError):
     pass
 
+def _mention_to_handle(args,ctx):
+    for x in args:
+        if x.startswith('<@!') :
+            linked_acc = cf_common.user_db.get_handle(x[3:-1],ctx.guild.id)
+            if not linked_acc:
+                raise CodeforcesCogError(
+                    f"Handle for <@!{x[3:-1]}> not found in database"
+                )
+            else:
+                x = linked_acc
 
 class Codeforces(commands.Cog):
     def __init__(self, bot):
@@ -202,6 +212,7 @@ class Codeforces(commands.Cog):
         (hardest,), args = cf_common.filter_flags(args, ["+hardest"])
         filt = cf_common.SubFilter(False)
         args = filt.parse(args)
+        args = _mention_to_handle(args,ctx)
         handles = args or ("!" + str(ctx.author),)
         handles = await cf_common.resolve_handles(ctx, self.converter, handles)
         submissions = [

--- a/tle/cogs/graphs.py
+++ b/tle/cogs/graphs.py
@@ -231,7 +231,16 @@ def _plot_average(practice, bin_size, label: str = ""):
             label=label,
         )
 
-
+def _mention_to_handle(args,ctx):
+    for x in args:
+        if x.startswith('<@!') :
+            linked_acc = cf_common.user_db.get_handle(x[3:-1],ctx.guild.id)
+            if not linked_acc:
+                raise GraphCogError(
+                    f"Handle for <@!{x[3:-1]}> not found in database"
+                )
+            else:
+                x = linked_acc
 class Graphs(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -256,6 +265,7 @@ class Graphs(commands.Cog):
         (zoom,), args = cf_common.filter_flags(args, ["+zoom"])
         filt = cf_common.SubFilter()
         args = filt.parse(args)
+        args = _mention_to_handle(args,ctx)
         handles = args or ("!" + str(ctx.author),)
         handles = await cf_common.resolve_handles(ctx, self.converter, handles)
         resp = [await cf.user.rating(handle=handle) for handle in handles]
@@ -360,6 +370,7 @@ class Graphs(commands.Cog):
         e.g. ;plot solved meooow +contest +virtual +outof +dp"""
         filt = cf_common.SubFilter()
         args = filt.parse(args)
+        args = _mention_to_handle(args,ctx)
         handles = args or ("!" + str(ctx.author),)
         handles = await cf_common.resolve_handles(ctx, self.converter, handles)
         resp = [await cf.user.status(handle=handle) for handle in handles]
@@ -437,6 +448,7 @@ class Graphs(commands.Cog):
         """Shows the histogram of problems solved over time on Codeforces for the handles provided."""
         filt = cf_common.SubFilter()
         args = filt.parse(args)
+        args = _mention_to_handle(args,ctx)
         handles = args or ("!" + str(ctx.author),)
         handles = await cf_common.resolve_handles(ctx, self.converter, handles)
         resp = [await cf.user.status(handle=handle) for handle in handles]
@@ -515,6 +527,7 @@ class Graphs(commands.Cog):
         Also plots a running average of ratings of problems solved in practice."""
         filt = cf_common.SubFilter()
         args = filt.parse(args)
+        args = _mention_to_handle(args,ctx)
         handle, bin_size, point_size = None, 10, 3
         for arg in args:
             if arg[0:2] == "b=":

--- a/tle/cogs/handles.py
+++ b/tle/cogs/handles.py
@@ -228,7 +228,7 @@ def _make_profile_embed(member, user, *, mode):
         embed = discord.Embed(description=desc, color=user.rank.color_embed)
         embed.add_field(name="Rating", value=user.rating, inline=True)
         embed.add_field(name="Rank", value=user.rank.title, inline=True)
-    embed.set_thumbnail(url=f"https:{user.titlePhoto}")
+    embed.set_thumbnail(url=f"{user.titlePhoto}")
     return embed
 
 


### PR DESCRIPTION
Seeing that quite a few people end up using mentions to use some commands in which you are required to give a codeforces handle (eg. plot rating), I felt that it would be a pretty useful feature to allow giving a codeforces handle or just tagging someone in the server to execute some of the commands.
Added this functionality to:
stalk
plot  rating, solved, hist, scatter.
